### PR TITLE
Exclude generic serial number string

### DIFF
--- a/IntuneCleanup/Invoke-IntuneCleanup.ps1
+++ b/IntuneCleanup/Invoke-IntuneCleanup.ps1
@@ -41,7 +41,7 @@ function Invoke-IntuneCleanup {
     Process {
         $devices = Get-IntuneManagedDevice | Get-MSGraphAllPages
         Write-Verbose "Found $($devices.Count) devices."
-        $deviceGroups = $devices | Where-Object { -not [String]::IsNullOrWhiteSpace($_.serialNumber) } | Group-Object -Property serialNumber
+        $deviceGroups = $devices | Where-Object { -not [String]::IsNullOrWhiteSpace($_.serialNumber) -and ($_.serialNumber -ne "Defaultstring") } | Group-Object -Property serialNumber
         $duplicatedDevices = $deviceGroups | Where-Object {$_.Count -gt 1 }
         Write-Verbose "Found $($duplicatedDevices.Count) serialNumbers with duplicated entries"
         foreach($duplicatedDevice in $duplicatedDevices){


### PR DESCRIPTION
In large tenants, "Defaultstring" is the serial number of a surprising number of active, non-duplicate, BYOD devices; this change excludes devices with that specific generic serial number.

Example output from before proposed exclusion…

VERBOSE: Serial Defaultstring
VERBOSE: # Keep DESKTOP-D9 10/24/2023 18:21:10
VERBOSE: # Remove DESKTOP-S9 10/24/2023 03:50:54
VERBOSE: # Remove DESKTOP-I0 10/20/2023 03:22:02
[…]